### PR TITLE
Create ISSUES.md

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,2 @@
+When I try to play certain torrents on the Apple TV I get the following error message: 
+`Crashed: com.popcorntimetv.popcorntorrent.alerts vector - Line 463 -[PTTorrentStreamer alertsLoop] + 463`. Would be happy if this could be fixed.


### PR DESCRIPTION
When I try to play certain torrents (often 2160p torrents) on the Apple TV I get the following error message: 
`Crashed: com.popcorntimetv.popcorntorrent.alerts vector - Line 463 -[PTTorrentStreamer alertsLoop] + 463` or `Crashed: com.popcorntimetv.popcorntorrent.alerts vector - Line 412 -[PTTorrentStreamer alertsLoop] + 412`. Would be happy if this could be fixed.
